### PR TITLE
Include error.h when make install

### DIFF
--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -1,6 +1,7 @@
 ZBOX_EXPORT = \
 	zbox.h \
 	zbox/common.h \
+	zbox/error.h \
 	zbox/file.h \
 	zbox/repo.h
 


### PR DESCRIPTION
Header is missing after performing `make install`.