### PR TITLE
Added missing linking libraries in tests

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,7 +2,7 @@ AM_CFLAGS = -I$(top_builddir)/src/include
 
 LDADD = \
 	$(top_builddir)/zbox-binding/target/release/libzbox.a \
-	-lsodium
+	-lsodium -lpthread -ldl
 
 TESTS_TARGETS = \
 	test_ffi


### PR DESCRIPTION
Compilations was falling with:
```
    Finished release [optimized] target(s) in 0.26s
make[1]: Leaving directory '/home/vagrant/zbox-c'
Making check in test
make[1]: Entering directory '/home/vagrant/zbox-c/test'
make  test_ffi
make[2]: Entering directory '/home/vagrant/zbox-c/test'
depbase=`echo test_ffi.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
gcc -DHAVE_CONFIG_H -I. -I..    -I../src/include -Wall -Werror -Wno-unused-function -MT test_ffi.o -MD -MP -MF $depbase.Tpo -c -o test_ffi.o test_ffi.c &&\
mv -f $depbase.Tpo $depbase.Po
/bin/bash ../libtool  --tag=CC   --mode=link gcc -I../src/include -Wall -Werror -Wno-unused-function   -o test_ffi test_ffi.o ../zbox-binding/target/release/libzbox.a -lsodium
libtool: link: gcc -I../src/include -Wall -Werror -Wno-unused-function -o test_ffi test_ffi.o  ../zbox-binding/target/release/libzbox.a -lsodium
/usr/bin/ld: ../zbox-binding/target/release/libzbox.a(zbox.zbox.2vcszkgi-cgu.2.rcgu.o): undefined reference to symbol 'pthread_rwlock_wrlock@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:559: recipe for target 'test_ffi' failed
make[2]: *** [test_ffi] Error 1
make[2]: Leaving directory '/home/vagrant/zbox-c/test'
Makefile:846: recipe for target 'check-am' failed
make[1]: *** [check-am] Error 2
make[1]: Leaving directory '/home/vagrant/zbox-c/test'
Makefile:474: recipe for target 'check-recursive' failed
```
and
```
 cd .. && /bin/bash /home/vagrant/zbox-c/build-aux/missing automake-1.15 --foreign test/Makefile
 cd .. && /bin/bash ./config.status test/Makefile depfiles
config.status: creating test/Makefile
config.status: executing depfiles commands
make: Nothing to be done for 'all'.
make  test_ffi
make[1]: Entering directory '/home/vagrant/zbox-c/test'
/bin/bash ../libtool  --tag=CC   --mode=link gcc -I../src/include -Wall -Werror -Wno-unused-function   -o test_ffi test_ffi.o ../zbox-binding/target/release/libzbox.a -lsodium -lpthread
libtool: link: gcc -I../src/include -Wall -Werror -Wno-unused-function -o test_ffi test_ffi.o  ../zbox-binding/target/release/libzbox.a -lsodium -lpthread
../zbox-binding/target/release/libzbox.a(std-51dacff11bee6a23.std.ancsozz9-cgu.13.rcgu.o): In function `std::sys::unix::weak::Weak<F>::get':
(.text._ZN3std3sys4unix4weak13Weak$LT$F$GT$3get17h4b22fe99707ddaacE+0x45): undefined reference to `dlsym'
../zbox-binding/target/release/libzbox.a(std-51dacff11bee6a23.std.ancsozz9-cgu.13.rcgu.o): In function `std::sys::unix::thread::Thread::new':
(.text._ZN3std3sys4unix6thread6Thread3new17hc354f3ef79d7dc4cE+0xcf): undefined reference to `dlsym'
../zbox-binding/target/release/libzbox.a(std-51dacff11bee6a23.std.ancsozz9-cgu.9.rcgu.o): In function `std::sys::unix::os::glibc_version':
(.text._ZN3std3sys4unix2os13glibc_version17h83517e7c5ff50d45E+0x51): undefined reference to `dlsym'
../zbox-binding/target/release/libzbox.a(backtrace-2841e3b206ea8a2e.backtrace.19d38bir-cgu.5.rcgu.o): In function `backtrace::symbolize::libbacktrace::resolve':
(.text._ZN9backtrace9symbolize12libbacktrace7resolve17h60066fd80bb813a6E+0x160): undefined reference to `dladdr'
(.text._ZN9backtrace9symbolize12libbacktrace7resolve17h60066fd80bb813a6E+0x1e1): undefined reference to `dladdr'
../zbox-binding/target/release/libzbox.a(std-51dacff11bee6a23.std.ancsozz9-cgu.1.rcgu.o): In function `std::sys::unix::process::process_inner::<impl std::sys::unix::process::process_common::Command>::spawn':
(.text._ZN3std3sys4unix7process13process_inner66_$LT$impl$u20$std..sys..unix..process..process_common..Command$GT$5spawn17h88803562972cde47E+0x67b): undefined reference to `dlsym'
collect2: error: ld returned 1 exit status
Makefile:559: recipe for target 'test_ffi' failed
make[1]: *** [test_ffi] Error 1
make[1]: Leaving directory '/home/vagrant/zbox-c/test'
Makefile:846: recipe for target 'check-am' failed
make: *** [check-am] Error 2
```